### PR TITLE
Fix menu overflow with many items

### DIFF
--- a/alt-linux/theme.txt
+++ b/alt-linux/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"

--- a/arch/theme.txt
+++ b/arch/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"

--- a/debian/theme.txt
+++ b/debian/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"

--- a/endeavouros/theme.txt
+++ b/endeavouros/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"

--- a/fedora/theme.txt
+++ b/fedora/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"

--- a/gentoo/theme.txt
+++ b/gentoo/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"

--- a/linux-generic/theme.txt
+++ b/linux-generic/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"

--- a/linux-mint/theme.txt
+++ b/linux-mint/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"

--- a/macos/theme.txt
+++ b/macos/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"

--- a/manjaro/theme.txt
+++ b/manjaro/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"

--- a/nixos/theme.txt
+++ b/nixos/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"

--- a/opensuse-generic/theme.txt
+++ b/opensuse-generic/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"

--- a/opensuse-tumbleweed/theme.txt
+++ b/opensuse-tumbleweed/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"

--- a/redhat/theme.txt
+++ b/redhat/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"

--- a/ubuntu/theme.txt
+++ b/ubuntu/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"

--- a/windows-dark/theme.txt
+++ b/windows-dark/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"

--- a/windows-light/theme.txt
+++ b/windows-light/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#363434"
   selected_item_color = "#4a4a4a"

--- a/zorin-os/theme.txt
+++ b/zorin-os/theme.txt
@@ -29,7 +29,7 @@ terminal-border: "0"
   left = 7%
   top = 41%
   width = 40%
-  height = 65%
+  height = 39%
   item_font = "DIN 2014 Regular 23"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"


### PR DESCRIPTION
Fixes #4, but with a different height. 39% fits better because it will have approximately the same margin on top and bottom of the container. Current numbers make no sense, since they surpass 100% of the screen. It works on any resolution, since it's based on percentage.

 For the packaged directory, let me know how you'd like that modified.